### PR TITLE
Made four changes in css(flex, examples-area,examples-card) so that w…

### DIFF
--- a/style.css
+++ b/style.css
@@ -86,6 +86,7 @@ ul {
 .flex {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .hover-link {
@@ -379,13 +380,14 @@ header {
 }
 
 .examples-area {
-  justify-content: space-between;
+  justify-content: center;
   margin-block: 30px;
   flex-wrap: wrap;
+  gap: 1rem;
 }
 
 .examples-card {
-  width: 23%;
+  width: 200px;
   position: relative;
   height: 300px;
   background: var(--secondary-text-color);
@@ -393,6 +395,7 @@ header {
     url(asset\ 35.jpeg);
   background-size: cover;
   transition: 0.2s ease-out;
+  border-radius: 15px;
 }
 
 .examples-card:hover {


### PR DESCRIPTION
## Problem
Examples card and below text sections were not very responsive for mobile view

## Solution
 changes in CSS like,

1. set examples card width from 23% to 200px.
2. For container's adjustments in the center, set the examples-area( justify-content: center;).
3. For a better view, the border radius have been set to 15px.
4. In flex class changes have been done like flex-wrap: wrap; .

## Screenshot
![Screenshot (223)](https://github.com/Rajan-Barnwal/jobproject/assets/140100457/b29385d2-1f0c-4d42-a661-216426bb5dfd)
![Screenshot (224)](https://github.com/Rajan-Barnwal/jobproject/assets/140100457/7eaaea19-8b73-4361-91ce-b008afd5af0b)